### PR TITLE
enforcing character limit restrictions per API

### DIFF
--- a/src/Request/Model/LineItem.php
+++ b/src/Request/Model/LineItem.php
@@ -80,17 +80,17 @@ class LineItem extends AbstractModel
 
     protected function setItemId($value)
     {
-        $this->itemId = $value;
+        $this->itemId = substr($value, 0, 31);
     }
 
     protected function setName($value)
     {
-        $this->name = $value;
+        $this->name = substr($value, 0, 31);
     }
 
     protected function setDescription($value)
     {
-        $this->description = $value;
+        $this->description = substr($value, 0, 255);
     }
 
     protected function setQuantity($value)


### PR DESCRIPTION
Schema has character limits on name, description and itemId. This is to enforce these limit and prevent errors on API calls. https://api.authorize.net/xml/v1/schema/AnetApiSchema.xsd